### PR TITLE
fix var access: resolve vars anonymously

### DIFF
--- a/sftp-connector-demo/src_hd/com/axonivy/connector/sftp/demo/SftpClientDemo/SftpClientDemoProcess.mod
+++ b/sftp-connector-demo/src_hd/com/axonivy/connector/sftp/demo/SftpClientDemo/SftpClientDemoProcess.mod
@@ -53,11 +53,10 @@ Ts0 f0 115 51 26 26 -16 15 #rect
 Ts0 f1 467 51 26 26 0 12 #rect
 Ts0 f9 actionTable 'out=in;
 ' #txt
-Ts0 f9 actionCode '
-in.clientHost = ivy.var.com_axonivy_connector_sftp_server_host;
-in.clientPort = Integer.parseInt(ivy.var.com_axonivy_connector_sftp_server_port);
-in.clientUsername = ivy.var.com_axonivy_connector_sftp_server_username;
-' #txt
+Ts0 f9 actionCode 'String prefix = "com_axonivy_connector_sftp_server_";
+in.clientHost = ivy.var.variable(prefix+"host").value();
+in.clientPort = Integer.parseInt(ivy.var.variable(prefix+"port").value());
+in.clientUsername = ivy.var.variable(prefix+"username").value();' #txt
 Ts0 f9 @C|.xml '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <elementInfo>
     <language>

--- a/sftp-connector/processes/Sftp/SftpHelper.mod
+++ b/sftp-connector/processes/Sftp/SftpHelper.mod
@@ -39,17 +39,20 @@ Sr0 f3 actionCode 'import com.axonivy.connector.sftp.service.SftpClientService;
 import java.lang.NumberFormatException;
 
 
-String host = ivy.var.com_axonivy_connector_sftp_server_host;
+String prefix = "com_axonivy_connector_sftp_server_";
+
+String host = ivy.var.variable(prefix+"host").value();
 Integer port = 22;
+String portRaw = ivy.var.variable(prefix+"port").value();
 try {
-	port = Integer.parseInt(ivy.var.com_axonivy_connector_sftp_server_port);
+	port = Integer.parseInt(portRaw);
 }
 catch(NumberFormatException nfe) {
 	ivy.log.error("The Global Variable: com.axonivy.connector.sftp.server.port = {0} does not contain a number. The default port number: {1} will be used instead.", 
-		nfe, ivy.var.com_axonivy_connector_sftp_server_port, port);
+		nfe, portRaw);
 }
-String username = ivy.var.com_axonivy_connector_sftp_server_username;
-String password = ivy.var.com_axonivy_connector_sftp_server_password;
+String username = ivy.var.variable(prefix+"username").value();
+String password = ivy.var.variable(prefix+"password").value();
 
 ivy.log.debug("The following settings will be used to connect to the SFTP server: hostname: {0}, port: {1}, username: {2}. Connection in progress...", 
 	host, port, username);


### PR DESCRIPTION
re-integrated from the market: the sftp connector seems to be unable to read variables. So we prefer the non typesafe implementation. At runtime the feature works as expected.