### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,45 +4,4 @@ on: workflow_dispatch
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v4.5
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v1.4.3
-        with:
-          java-version: 17
-          server-id: github
-
-      - name: Configure Git user
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git checkout -b new-release
-
-      - name: Install and start SFTP
-        run: |
-          sudo apt install openssh-server
-          sudo systemctl enable ssh
-          sudo systemctl start ssh
-
-      - name: Create a test user account
-        run: sudo useradd -s /bin/bash -d /home/usr -m -g ssh -p $(echo pwd | openssl passwd -1 -stdin) usr
-        
-      - name: Build with Maven
-        run: mvn --batch-mode -Darguments="-DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/${{ github.event.repository.name }}" release:prepare release:perform
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: pull-request
-        uses: repo-sync/pull-request@v2
-        with:
-          destination_branch: ${{ steps.branch-name.outputs.current_branch }}
-          source_branch: new-release
-          pr_title: "Release"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: axonivy-market/github-workflows/.github/workflows/release.yml@v2


### PR DESCRIPTION
We can use the reusable pipeline for the release. We decided that we don't run any tests while releasing, to prevent errors in this case.

For the ci pipeline it's not possible here at the moment. But we could make our ci pipeline more configurable, that you can pass for example a "PRE_SH_COMMAND".